### PR TITLE
Fix: Exclude symlinks from duplicate search.

### DIFF
--- a/duplicate_finder_v7.py
+++ b/duplicate_finder_v7.py
@@ -75,8 +75,11 @@ class DuplicateFinderGPU:
             if self.stop_flag:
                 return {}
                 
-            if file_path.is_file():
+            if file_path.is_file() and not file_path.is_symlink():
                 try:
+                    # For regular files, stat() follows symlinks by default.
+                    # However, we've excluded symlinks above.
+                    # So, this will only be called on actual files.
                     stat = file_path.stat()
                     size = stat.st_size
                     if size >= self.min_size:


### PR DESCRIPTION
I've modified the `find_large_files` function to ensure that symbolic links are not processed during the duplicate file search. Only actual files will be considered for hashing and comparison.

Note: An outstanding issue remains where individual file selections for symlink creation are not correctly updated from the UI to the backend. The `create_symlinks` Python function itself is logically sound based on the data it receives, but the frontend checkboxes for individual duplicates do not currently trigger a backend state update. This requires further Gradio UI development.