### PR TITLE
Fix: Resolve TypeError in gr.HTML component

### DIFF
--- a/duplicate_ui_fixed.py
+++ b/duplicate_ui_fixed.py
@@ -396,7 +396,7 @@ def create_interface_components():
             # 180px -> scale 3
             # 120px -> scale 2
             gr.Column(name_sort_actual_button, scale=2, min_width=80)
-            gr.HTML("<div class='header-cell select-col'></div>", scale=1, min_width=60) # For the select column (empty header)
+            gr.Column(gr.HTML("<div class='header-cell select-col'></div>"), scale=1, min_width=60) # For the select column (empty header)
             gr.HTML("<div class='header-cell filename-col'>Archivo</div>", scale=7) # File
             gr.HTML("<div class='header-cell datetime-col'>Fecha Modificación</div>", scale=3, min_width=180) # Date
             gr.Column(size_sort_actual_button, scale=2, min_width=120)


### PR DESCRIPTION
The gr.HTML component was being initialized with 'scale' and 'min_width' parameters, which are not supported by this component, leading to a TypeError.

This commit fixes the issue by wrapping the gr.HTML component in a gr.Column and applying the 'scale' and 'min_width' layout parameters to the gr.Column instead. This aligns with the correct Gradio API usage for controlling layout.